### PR TITLE
Fix problem on deferred creaton of IScroll object

### DIFF
--- a/simple-list.html
+++ b/simple-list.html
@@ -17,6 +17,11 @@
 
       Polymer({
 
+        // Fix problem on deferred creaton of IScroll object
+        get scroll() {
+            return this.$.scroller.scroll;
+        },
+
         /**
          *
          */
@@ -25,8 +30,8 @@
           this.super(arguments);
 
           // replace default scroll target
-          this.scrollTarget = this.$.scroller;
-          this.scroll = this.scrollTarget.scroll;
+          //this.scrollTarget = this.$.scroller;
+          //this.scroll = this.scrollTarget.scroll;
         },
 
         /**


### PR DESCRIPTION
Due that  IScroll object is created in deferred mode (ie. setTimeout) i've added a "get property" instead of initialise the properties in ready method
